### PR TITLE
Add ability to read IgnorePkg array from pacman.conf

### DIFF
--- a/update-check
+++ b/update-check
@@ -2,7 +2,7 @@
 
 #set -x
 
-trap 'rm /tmp/{pacmanupdates,aurupdates,ignorepkg} 2>/dev/null' INT TERM QUIT EXIT
+trap 'rm /tmp/{pacmanupdates,aurupdates,ignorepkgs} 2>/dev/null' INT TERM QUIT EXIT
 
 if ! $(ping -c 3 google.com >> /dev/null 2>&1); then
 	exit
@@ -30,8 +30,8 @@ if ((nb_pac>0 || nb_aur>0)); then
   pkgs="$(grep IgnorePkg /etc/pacman.conf | sed -e 's/IgnorePkg =//' -e 's/#.*//')"
   grps="$(grep IgnoreGroup /etc/pacman.conf | sed -e 's/IgnoreGroup =//' -e 's/#.*//')"
   [[ -n $grps ]] && pkgs="$pkgs $(pacman -Sgq $grps)"
-  echo $pkgs | sed 's:IgnorePkg = ::g' > /tmp/ignorepkg
-  for i in $(cat /tmp/ignorepkg); do
+  echo $pkgs | sed 's:IgnorePkg = ::g' > /tmp/ignorepkgs
+  for i in $(cat /tmp/ignorepkgs); do
   	sed -i -e "/$i/d" /tmp/aurupdates
   done
   cat /tmp/pacmanupdates 

--- a/update-check
+++ b/update-check
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-trap 'rm /tmp/{pacmanupdates,aurupdates} 2>/dev/null' INT TERM QUIT EXIT
+#set -x
+
+trap 'rm /tmp/{pacmanupdates,aurupdates,ignorepkg} 2>/dev/null' INT TERM QUIT EXIT
 
 if ! $(ping -c 3 google.com >> /dev/null 2>&1); then
 	exit
@@ -23,6 +25,15 @@ fi
 if ((nb_pac>0 || nb_aur>0)); then
   ((nb_aur>0)) && nb_aur="+ ${nb_aur}"
   ((nb_aur==0)) && unset nb_aur
+
+# Check the Ignore array in pacman.conf
+  pkgs="$(grep IgnorePkg /etc/pacman.conf | sed -e 's/IgnorePkg =//' -e 's/#.*//')"
+  grps="$(grep IgnoreGroup /etc/pacman.conf | sed -e 's/IgnoreGroup =//' -e 's/#.*//')"
+  [[ -n $grps ]] && pkgs="$pkgs $(pacman -Sgq $grps)"
+  echo $pkgs | sed 's:IgnorePkg = ::g' > /tmp/ignorepkg
+  for i in $(cat /tmp/ignorepkg); do
+  	sed -i -e "/$i/d" /tmp/aurupdates
+  done
   cat /tmp/pacmanupdates 
   cat /tmp/aurupdates
 fi


### PR DESCRIPTION
Hi Matti, today played with bash to find a solution for manage ignore pkgs from AUR. My additions seem work fine ( tested in my locale, recheck if you find time ). The advantage now is we not depends on wrapper if the wrapper not consider the ignore array .. My additions are ready also for manage Groups but i think is not necessary since in AUR we not ignore groups .. let me know what you think :)