### PR TITLE
Use pacman-mirrors API to obtain branch

### DIFF
--- a/update-check
+++ b/update-check
@@ -40,30 +40,28 @@ if ((nb_pac>0 || nb_aur>0)); then
   for i in $(cat /tmp/ignorepkgs); do
   	sed -i -e "/$i/d" /tmp/aurupdates
   done
-  cat /tmp/pacmanupdates 
+  cat /tmp/pacmanupdates
   cat /tmp/aurupdates
 fi
 
-if [[ -e /var/lib/pacman/sync/core.db ]]; then 
+if [[ -e /var/lib/pacman/sync/core.db ]]; then
 	# Check if the running kernel is eol
-	if ! pacman -Ssq $(mhwd-kernel -li | awk 'NR==1 {print $4}' | tr -d '()') &> /dev/null; then 
+	if ! pacman -Ssq $(mhwd-kernel -li | awk 'NR==1 {print $4}' | tr -d '()') &> /dev/null; then
 		msm=$(dunstify -A manjaro-settings-manager,ACCEPT -A true,DECLINE "Your kernel is no longer supported" "Please change kernel with Manjaro Settings Manager")
 		[[ "$msm" == "manjaro-settings-manager" ]] && manjaro-settings-manager &> /dev/null &
 	fi
-	
+
 	# Branch
-	if ! $(grep -q "^Branch" /etc/pacman-mirrors.conf); then 
-	  branch=stable
-	  capital_branch=Stable
-	else
-	  branch=$(awk '/Branch =/{print $3}' /etc/pacman-mirrors.conf)
+	if [[ -x /usr/bin/pacman-mirrors ]]; then
+    branch=$(/usr/bin/pacman-mirrors -G)
 	  capital_branch=$(echo $branch | sed 's/\b[a-z]/\u&/g')
-	fi
-	# timestamp update announcements. 
-	last_annoncement=$(curl https://forum.manjaro.org/c/announcements/"$branch"-updates.rss 2> /dev/null | awk '/<title>/' | awk -v br="$capital_branch" '/\[br Update\]/{print $3}' | head -n1)
+  fi
+
+	# timestamp update announcements.
+	last_announcement=$(curl https://forum.manjaro.org/c/announcements/"$branch"-updates.rss 2> /dev/null | awk '/<title>/' | awk -v br="$capital_branch" '/\[br Update\]/{print $3}' | head -n1)
 	# timestamp of last update
 	last_update=$(awk '/upgrade/ {print $1}' /var/log/pacman.log | sed 's/\[//' | tail -n1)
-	if [[ $last_annoncement > $last_update ]]; then
+	if [[ $last_announcement > $last_update ]]; then
 		answer=$(dunstify -A terminal_update,YES -A true,NO "Update requires user input. Advice in forum announcements." "Run next update in terminal?")
 		case $(echo answer) in
 		terminal_update)


### PR DESCRIPTION
Other minor changes: remove trailing spaces and fix typo.

`pacman-mirrors` since some version has an API to obtain user branch without directly reading the configuration file, better for future compatibility.