### PR TITLE
Many checks, add terminal function

### DIFF
--- a/update-check
+++ b/update-check
@@ -4,23 +4,23 @@
 
 trap 'rm /tmp/{pacmanupdates,aurupdates,ignorepkgs} 2>/dev/null' INT TERM QUIT EXIT
 
-if ! $(curl -s --max-time 10 google.com >> /dev/null 2>&1); then
+if ! curl -s --max-time 10 google.com >> /dev/null 2>&1; then
 	exit
 elif [[ -e /run/miso/bootmnt ]]; then
 	exit
 fi
 
 nb_pac=$(checkupdates | tee /tmp/pacmanupdates | wc -l)
-if [ -f /usr/bin/yay ]; then
+if [ -x /usr/bin/yay ]; then
    nb_aur=$(yay -Qua | tee /tmp/aurupdates | wc -l)
    update_command="yay -Syu"
-elif [ -f /usr/bin/trizen ]; then
+elif [ -x /usr/bin/trizen ]; then
    nb_aur=$(trizen -Qua 2>&1 | cut -d" " -f 2,6,7,8 | sed -e 's/[()]//g' | tee /tmp/aurupdates | wc -l)
    update_command="trizen -Syua"
-elif [ -f /usr/bin/pacaur ]; then
+elif [ -x /usr/bin/pacaur ]; then
    nb_aur=$(pacaur -Qua | awk '$2 == "aur" {print $3 $4 $5 $6}' | tee /tmp/aurupdates | wc -l)
    update_command="pacaur -Syu"
-elif [ -f /usr/bin/yaourt ]; then
+elif [ -x /usr/bin/yaourt ]; then
     nb_aur=$(yaourt -Qua | grep "^aur/" | tee /tmp/aurupdates | wc -l)
     update_command="yaourt -Syua"
 else
@@ -32,7 +32,7 @@ if ((nb_pac>0 || nb_aur>0)); then
   ((nb_aur>0)) && nb_aur="+ ${nb_aur}"
   ((nb_aur==0)) && unset nb_aur
 
-# Check the Ignore array in pacman.conf
+	# Check the Ignore array in pacman.conf
   pkgs="$(grep IgnorePkg /etc/pacman.conf | sed -e 's/IgnorePkg =//' -e 's/#.*//')"
   grps="$(grep IgnoreGroup /etc/pacman.conf | sed -e 's/IgnoreGroup =//' -e 's/#.*//')"
   [[ -n $grps ]] && pkgs="$pkgs $(pacman -Sgq $grps)"
@@ -46,7 +46,7 @@ fi
 
 if [[ -e /var/lib/pacman/sync/core.db ]]; then
 	# Check if the running kernel is eol
-	if ! pacman -Ssq $(mhwd-kernel -li | awk 'NR==1 {print $4}' | tr -d '()') &> /dev/null; then
+	if ! pacman -Ssq "$(mhwd-kernel -li | awk 'NR==1 {print $4}' | tr -d '()')" &> /dev/null; then
 		msm=$(dunstify -A manjaro-settings-manager,ACCEPT -A true,DECLINE "Your kernel is no longer supported" "Please change kernel with Manjaro Settings Manager")
 		[[ "$msm" == "manjaro-settings-manager" ]] && manjaro-settings-manager &> /dev/null &
 	fi
@@ -54,7 +54,10 @@ if [[ -e /var/lib/pacman/sync/core.db ]]; then
 	# Branch
 	if [[ -x /usr/bin/pacman-mirrors ]]; then
     branch=$(/usr/bin/pacman-mirrors -G)
-	  capital_branch=$(echo $branch | sed 's/\b[a-z]/\u&/g')
+	  capital_branch="$(echo $branch | sed 's/\b[a-z]/\u&/g')"
+	else
+		echo "ERROR: 'pacman-mirrors' command not found, is this a valid Manjaro Linux installation?" 1>&2
+		exit 1
   fi
 
 	# timestamp update announcements.
@@ -63,7 +66,7 @@ if [[ -e /var/lib/pacman/sync/core.db ]]; then
 	last_update=$(awk '/upgrade/ {print $1}' /var/log/pacman.log | sed 's/\[//' | tail -n1)
 	if [[ $last_announcement > $last_update ]]; then
 		answer=$(dunstify -A terminal_update,YES -A true,NO "Update requires user input. Advice in forum announcements." "Run next update in terminal?")
-		case $(echo answer) in
+		case $answer in
 		terminal_update)
 			touch /tmp/.manual_update
 			;;

--- a/update-help
+++ b/update-help
@@ -1,15 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
-if [ -f /usr/bin/yay ]; then
+if [ -x /usr/bin/yay ]; then
    nb_aur=$(yay -Qua | tee /tmp/aurupdates | wc -l)
    update_command="yay -Syu"
-elif [ -f /usr/bin/trizen ]; then
+elif [ -x /usr/bin/trizen ]; then
    nb_aur=$(trizen -Qua 2>&1 | cut -d" " -f 2,6,7,8 | sed -e 's/[()]//g' | tee /tmp/aurupdates | wc -l)
    update_command="trizen -Syua"
-elif [ -f /usr/bin/pacaur ]; then
+elif [ -x /usr/bin/pacaur ]; then
    nb_aur=$(pacaur -Qua | awk '$2 == "aur" {print $3 $4 $5 $6}' | tee /tmp/aurupdates | wc -l)
    update_command="pacaur -Syu"
-elif [ -f /usr/bin/yaourt ]; then
+elif [ -x /usr/bin/yaourt ]; then
     nb_aur=$(yaourt -Qua | grep "^aur/" | tee /tmp/aurupdates | wc -l)
     update_command="yaourt -Syua"
 else

--- a/update-notifier
+++ b/update-notifier
@@ -2,15 +2,47 @@
 
 . ~/.profile
 trap 'rm /tmp/{pacmanupdates,aurupdates} 2>/dev/null' INT TERM QUIT EXIT
+
+# check if some known terminal is installed
+#  and print it to stdout
+terminal()
+{
+  if [ "$(command -v sterminal)" ]; then
+    echo "sterminal"
+  elif [ "$(command -v urxvt)" ]; then
+    echo "urxvt"
+  elif [ "$(command -v termite)" ]; then
+    echo "termite"
+  elif [ "$(command -v terminator)" ]; then
+    echo "terminator"
+  elif [ "$(command -v sakura)" ]; then
+    echo "sakura"
+  elif [ "$(command -v lxterminal)" ]; then
+    echo "lxterminal"
+  elif [ "$(command -v xfce4-terminal)" ]; then
+    echo "xfce4-terminal"
+  elif [ "$(command -v gnome-terminal)" ]; then
+    echo "gnome-terminal"
+  elif [ "$(command -v konsole)" ]; then
+    echo "konsole"
+  elif [ "$(command -v qterminal)" ]; then
+    echo "qterminal"
+  elif [ "$(command -v xterm)" ]; then
+    echo "xterm"
+  else
+    echo ""
+  fi
+}
+
 nb_pac=$(checkupdates | tee /tmp/pacmanupdates | wc -l)
 
-if [ -f /usr/bin/yay ]; then
+if [ -x /usr/bin/yay ]; then
    nb_aur=$(yay -Qua | tee /tmp/aurupdates | wc -l)
-elif [ -f /usr/bin/trizen ]; then
+elif [ -x /usr/bin/trizen ]; then
     nb_aur=$(trizen -Qua 2>&1 | cut -d" " -f 2,6,7,8 | sed -e 's/[()]//g' | tee /tmp/aurupdates | wc -l)
-elif [ -f /usr/bin/pacaur ]; then
+elif [ -x /usr/bin/pacaur ]; then
    nb_aur=$(pacaur -Qua | awk '$2 == "aur" {print $3 $4 $5 $6}' | tee /tmp/aurupdates | wc -l)
-elif [ -f /usr/bin/yaourt ]; then
+elif [ -x /usr/bin/yaourt ]; then
     nb_aur=$(yaourt -Qua | grep "^aur/" | tee /tmp/aurupdates | wc -l)
 else
    nb_aur=0
@@ -18,40 +50,19 @@ fi
 
 
 if [ -z "$TERMINAL" ]; then
-  if [ "$(which sterminal)" ]; then
-    echo "export TERMINAL=\"sterminal\"" >> ~/.profile
-    TERMINAL="sterminal"
-  elif [ "$(which urxvt)" ]; then
-    echo "export TERMINAL=\"urxvt\"" >> ~/.profile
-    TERMINAL="urxvt"
-  elif [ "$(which termite)" ]; then
-    echo "export TERMINAL=\"termite\"" >> ~/.profile
-    TERMINAL="termite"
-  elif [ "$(which terminator)" ]; then
-    echo "export TERMINAL=\"terminator\"" >> ~/.profile
-    TERMINAL="terminator"
-  elif [ "$(which sakura)" ]; then
-    TERMINAL="sakura"
-    echo "export TERMINAL=\"sakura\"" >> ~/.profile
-  elif [ "$(which lxterminal)" ]; then
-    echo "export TERMINAL=\"lxterminal\"" >> ~/.profile
-    TERMINAL="lxterminal"
-  elif [ "$(which xfce4-terminal)" ]; then
-    TERMINAL="xfce4-terminal"
-    echo "export TERMINAL=\"xfce4-terminal\"" >> ~/.profile
-  elif [ "$(which gnome-terminal)" ]; then
-    echo "export TERMINAL=\"gnome-terminal\"" >> ~/.profile
-    TERMINAL="gnome-terminal"
-  elif [ "$(which konsole)" ]; then
-    TERMINAL="konsole"
-    echo "export TERMINAL=\"konsole\"" >> ~/.profile
-  elif [ "$(which qterminal)" ]; then
-    TERMINAL="qterminal"
-    echo "export TERMINAL=\"qterminal\"" >> ~/.profile
-  elif [ "$(which xterm)" ]; then
-    TERMINAL="xterm"
-    echo "export TERMINAL=\"xterm\"" >> ~/.profile
+  TERMINAL=$(eval terminal)
+  if [ -z "$TERMINAL" ]; then
+    echo "ERROR: no known terminal emulator found, please update your TERMINAL environment variable." 1>&2
+    exit 1
   fi
+  echo "export TERMINAL=\"$TERMINAL\"" >> ~/.profile
+elif [ ! -x "$(command -v "$TERMINAL")" ]; then
+  echo "ERROR: '$TERMINAL' not found, please update your TERMINAL environment variable." 1>&2
+  if [ -z "$TERMINAL" ]; then
+    echo "ERROR: no known terminal emulator found, please update your TERMINAL environment variable." 1>&2
+    exit 1
+  fi
+  TERMINAL=$(eval terminal)
 fi
 
 if ((nb_pac>0 || nb_aur>0)); then
@@ -59,10 +70,11 @@ if ((nb_pac>0 || nb_aur>0)); then
   ((nb_aur==0)) && unset nb_aur
   answer=$(dunstify "You have ${nb_pac} ${nb_aur} updates" "$(cat /tmp/pacmanupdates)" \
    -A Y,"Update now" -A N,Later)
-    case $(echo $answer) in
+    case $answer in
       Y) $TERMINAL -e update-help
         ;;
-    *) echo "$answer no match"
+    	*) echo "$answer no match"
+				;;
     esac
 else
   dunstify "Your system is up to date" "No packages to update"


### PR DESCRIPTION
update-notifier: add terminal() to find a known terminal, check for
execution permission on AUR helpers, check for outdated TERMINAL env
variable.

update-help: set as bash script because 'read -p' is not POSIX sh, check
for execution permission on AUR helpers.

update-check: remove useless $() in 'if' statement, check for execution
permission on AUR helpers, add "" to prevent words splitting, check
pacman-mirrors is installed before using it.

Many syntax modifications are not my own idea but taken from
'shellcheck' output, it is a precious piece of software.

Sorry for the messy commit, it contains a lot of different topic, I'll do better on the next one.