### PR TITLE
Check connection, fix trizen update parsing

### DIFF
--- a/update-check
+++ b/update-check
@@ -15,7 +15,7 @@ if [ -x /usr/bin/yay ]; then
    nb_aur=$(yay -Qua | tee /tmp/aurupdates | wc -l)
    update_command="yay -Syu"
 elif [ -x /usr/bin/trizen ]; then
-   nb_aur=$(trizen -Qua 2>&1 | cut -d" " -f 2,6,7,8 | sed -e 's/[()]//g' | tee /tmp/aurupdates | wc -l)
+   nb_aur=$(trizen -Qua | tee /tmp/aurupdates | wc -l)
    update_command="trizen -Syua"
 elif [ -x /usr/bin/pacaur ]; then
    nb_aur=$(pacaur -Qua | awk '$2 == "aur" {print $3 $4 $5 $6}' | tee /tmp/aurupdates | wc -l)

--- a/update-checker
+++ b/update-checker
@@ -5,6 +5,7 @@ connection()
 {
     curl -s --max-time 10 google.com >/dev/null 2>&1
 }
+
 checker()
 {
 while true; do

--- a/update-help
+++ b/update-help
@@ -4,7 +4,7 @@ if [ -x /usr/bin/yay ]; then
    nb_aur=$(yay -Qua | tee /tmp/aurupdates | wc -l)
    update_command="yay -Syu"
 elif [ -x /usr/bin/trizen ]; then
-   nb_aur=$(trizen -Qua 2>&1 | cut -d" " -f 2,6,7,8 | sed -e 's/[()]//g' | tee /tmp/aurupdates | wc -l)
+   nb_aur=$(trizen -Qua | tee /tmp/aurupdates | wc -l)
    update_command="trizen -Syua"
 elif [ -x /usr/bin/pacaur ]; then
    nb_aur=$(pacaur -Qua | awk '$2 == "aur" {print $3 $4 $5 $6}' | tee /tmp/aurupdates | wc -l)

--- a/update-notifier
+++ b/update-notifier
@@ -3,51 +3,67 @@
 . ~/.profile
 trap 'rm /tmp/{pacmanupdates,aurupdates} 2>/dev/null' INT TERM QUIT EXIT
 
+# check internet connection
+connection()
+{
+curl -s --max-time 10 google.com >/dev/null 2>&1
+}
+
 # check if some known terminal is installed
 #  and print it to stdout
 terminal()
 {
-  if [ "$(command -v sterminal)" ]; then
-    echo "sterminal"
-  elif [ "$(command -v urxvt)" ]; then
-    echo "urxvt"
-  elif [ "$(command -v termite)" ]; then
-    echo "termite"
-  elif [ "$(command -v terminator)" ]; then
-    echo "terminator"
-  elif [ "$(command -v sakura)" ]; then
-    echo "sakura"
-  elif [ "$(command -v lxterminal)" ]; then
-    echo "lxterminal"
-  elif [ "$(command -v xfce4-terminal)" ]; then
-    echo "xfce4-terminal"
-  elif [ "$(command -v gnome-terminal)" ]; then
-    echo "gnome-terminal"
-  elif [ "$(command -v konsole)" ]; then
-    echo "konsole"
-  elif [ "$(command -v qterminal)" ]; then
-    echo "qterminal"
-  elif [ "$(command -v xterm)" ]; then
-    echo "xterm"
-  else
-    echo ""
-  fi
+if [ "$(command -v sterminal)" ]; then
+  echo "sterminal"
+elif [ "$(command -v urxvt)" ]; then
+  echo "urxvt"
+elif [ "$(command -v termite)" ]; then
+  echo "termite"
+elif [ "$(command -v terminator)" ]; then
+  echo "terminator"
+elif [ "$(command -v sakura)" ]; then
+  echo "sakura"
+elif [ "$(command -v lxterminal)" ]; then
+  echo "lxterminal"
+elif [ "$(command -v xfce4-terminal)" ]; then
+  echo "xfce4-terminal"
+elif [ "$(command -v gnome-terminal)" ]; then
+  echo "gnome-terminal"
+elif [ "$(command -v konsole)" ]; then
+  echo "konsole"
+elif [ "$(command -v qterminal)" ]; then
+  echo "qterminal"
+elif [ "$(command -v xterm)" ]; then
+  echo "xterm"
+else
+  echo ""
+fi
 }
+
+# list AUR updates and count them
+aur_check()
+{
+if [ -x /usr/bin/yay ]; then
+	yay -Qua | tee /tmp/aurupdates | wc -l
+elif [ -x /usr/bin/trizen ]; then
+	trizen -Qua | cut -d" " -f 2,6,7,8 | sed -e 's/[()]//g' | tee /tmp/aurupdates | wc -l
+elif [ -x /usr/bin/pacaur ]; then
+	pacaur -Qua | awk '$2 == "aur" {print $3 $4 $5 $6}' | tee /tmp/aurupdates | wc -l
+elif [ -x /usr/bin/yaourt ]; then
+	yaourt -Qua | grep "^aur/" | tee /tmp/aurupdates | wc -l
+else
+	echo 0
+fi
+}
+
 
 nb_pac=$(checkupdates | tee /tmp/pacmanupdates | wc -l)
 
-if [ -x /usr/bin/yay ]; then
-   nb_aur=$(yay -Qua | tee /tmp/aurupdates | wc -l)
-elif [ -x /usr/bin/trizen ]; then
-    nb_aur=$(trizen -Qua 2>&1 | cut -d" " -f 2,6,7,8 | sed -e 's/[()]//g' | tee /tmp/aurupdates | wc -l)
-elif [ -x /usr/bin/pacaur ]; then
-   nb_aur=$(pacaur -Qua | awk '$2 == "aur" {print $3 $4 $5 $6}' | tee /tmp/aurupdates | wc -l)
-elif [ -x /usr/bin/yaourt ]; then
-    nb_aur=$(yaourt -Qua | grep "^aur/" | tee /tmp/aurupdates | wc -l)
+if connection; then
+	nb_aur=$(eval aur_check)
 else
-   nb_aur=0
+	echo "No internet connection, AUR updates skipped." 1>&2
 fi
-
 
 if [ -z "$TERMINAL" ]; then
   TERMINAL=$(eval terminal)
@@ -68,12 +84,14 @@ fi
 if ((nb_pac>0 || nb_aur>0)); then
   ((nb_aur>0)) && nb_aur="+ ${nb_aur}" && cat /tmp/aurupdates >> /tmp/pacmanupdates
   ((nb_aur==0)) && unset nb_aur
-  answer=$(dunstify "You have ${nb_pac} ${nb_aur} updates" "$(cat /tmp/pacmanupdates)" \
-   -A Y,"Update now" -A N,Later)
+  answer=$(dunstify "You have ${nb_pac} ${nb_aur} updates" \
+		"$(cat /tmp/pacmanupdates)" -A Y,"Update now" -A N,Later)
     case $answer in
       Y) $TERMINAL -e update-help
         ;;
-    	*) echo "$answer no match"
+    	N)
+				;;
+			*) echo "'$answer' no match" 1>&2
 				;;
     esac
 else

--- a/update-notifier
+++ b/update-notifier
@@ -46,7 +46,7 @@ aur_check()
 if [ -x /usr/bin/yay ]; then
 	yay -Qua | tee /tmp/aurupdates | wc -l
 elif [ -x /usr/bin/trizen ]; then
-	trizen -Qua | cut -d" " -f 2,6,7,8 | sed -e 's/[()]//g' | tee /tmp/aurupdates | wc -l
+	trizen -Qua | tee /tmp/aurupdates | wc -l
 elif [ -x /usr/bin/pacaur ]; then
 	pacaur -Qua | awk '$2 == "aur" {print $3 $4 $5 $6}' | tee /tmp/aurupdates | wc -l
 elif [ -x /usr/bin/yaourt ]; then


### PR DESCRIPTION
Add connection check to update-notifier, otherwise `yay` prints errors, apart from that I think it can save execution time.

Remove stderr from `trizen` output, otherwise it can list non existent updates, for example ingored packages add 1 to the line count.
Remove `cut` from `trizen` update parsing command, otherwise the output file (and notification message) looks like `8.1.0` instead of `pkgname 8.0.8 -> 8.1.0`.

Do not print anything if the user select "Later" in the notification box, print an error only if there is an unknown answer.